### PR TITLE
BASW-155: Make sure that the module work only on civicrm webform

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -10,6 +10,10 @@
  * @param $submission
  */
 function webform_civicrm_membership_extras_webform_submission_insert($node, $submission) {
+  if (!_membershipextras_isCivicrmWebform($node)) {
+    return;
+  }
+
   $contributionRecurId = _membershipextras_getPaymentPlanRecurContribution($node);
 
   if (!empty($contributionRecurId)) {
@@ -17,6 +21,22 @@ function webform_civicrm_membership_extras_webform_submission_insert($node, $sub
     $installmentsHandler = new CRM_MembershipExtras_Service_MembershipInstallmentsHandler($contributionRecurId);
     $installmentsHandler->createRemainingInstalmentContributionsUpfront();
   }
+}
+
+/**
+ * Determines if "CiviCRM  Processing" is enabled on
+ * the Webform.
+ *
+ * @param $node
+ *
+ * @return bool
+ */
+function _membershipextras_isCivicrmWebform($node) {
+  if (property_exists($node, 'webform_civicrm')) {
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**


### PR DESCRIPTION
I was calling  : 

 **wf_crm_webform_postprocess::singleton($node)**

which only work if the webform is a civicrm-enabled wbform which causes fatal error when submitting a non civicrm-enabled webform.

And because we only need this module to work if the webform is civicrm-enabled, I've added an extra check to ensure that the module only work for civicrm-enabled webforms.