### PR TITLE
BASW-392: Fix error with discount code usage limit.

### DIFF
--- a/includes/wf_me_discount_code_validator.inc
+++ b/includes/wf_me_discount_code_validator.inc
@@ -24,7 +24,7 @@ class wf_me_discount_code_validator {
     }
 
     // Validate discount code usage limit.
-    if (!empty($discountCodeDetails['count_max']) && $discountCodeDetails['count_max'] >= $discountCodeDetails['count_use']) {
+    if (!empty($discountCodeDetails['count_max']) && $discountCodeDetails['count_use'] >= $discountCodeDetails['count_max']) {
       throw new Exception(t('Discount code usage exceeded.'));
     }
 


### PR DESCRIPTION
## Problem
Cividiscount was integrated with webform in #2 but there is an issue with using discount code with usage limit set, as the error `Discount code usage exceeded.` is always displayed.

## Solution
There was an error in the validation logic which was always checking of the maximum usage number is greater or equal to the number of times the discount code has been used, the fix was to reverse this condition.