### PR TITLE
BASW-363: Fix Bug Caused By Wrong Contribution Instalments Value

### DIFF
--- a/includes/wf_me_discount_amount_helper.inc
+++ b/includes/wf_me_discount_amount_helper.inc
@@ -20,15 +20,22 @@ class wf_me_discount_amount_helper {
    */
   private $formStorage;
 
+  /**
+   * @var array
+   */
+  private $form;
+
   private $numberOfInstallments;
 
   /**
    * wf_me_discount_amount_helper constructor.
    *
    * @param array $formStorage
+   * @param array $form
    */
-  public function __construct($formStorage) {
+  public function __construct($form, $formStorage) {
     $this->formStorage = $formStorage;
+    $this->form = $form;
   }
 
   /**
@@ -186,7 +193,7 @@ class wf_me_discount_amount_helper {
    */
   public function getNumberOfInstallments() {
     if (!$this->numberOfInstallments) {
-      $webformComponents = $this->formStorage['component_tree']['children'];
+      $webformComponents = $this->form['#node']->webform['components'];
       $installments_key = '';
       $installments = '';
       foreach ($webformComponents as $key => $value) {

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -207,7 +207,7 @@ function _set_discount_code_status_in_session($status) {
  * @param array $form_state
  */
 function _set_discounted_membership_items_in_session($form, &$form_state) {
-  $wf_me_discount_amount_helper = new wf_me_discount_amount_helper($form_state['storage']);
+  $wf_me_discount_amount_helper = new wf_me_discount_amount_helper($form, $form_state['storage']);
   $number_of_installments = $wf_me_discount_amount_helper->getNumberOfInstallments();
   $membership_type_added = array();
   foreach ($form_state['line_items'] as $item) {
@@ -347,7 +347,7 @@ function _webform_discount_code_field_submit_callback($form, &$form_state) {
 
     $line_items = $form_state['civicrm']['line_items'];
     $discount_code = $form_values['webform_discount_code_field'];
-    $wf_me_discount_amount_helper = new wf_me_discount_amount_helper($form_state['storage']);
+    $wf_me_discount_amount_helper = new wf_me_discount_amount_helper($form, $form_state['storage']);
     $adjusted_line_items = $wf_me_discount_amount_helper->getAdjustedLineItems($discount_code, $line_items, $membership_type_added);
 
     if (!empty($adjusted_line_items)) {


### PR DESCRIPTION
## Problem
When the discount code is applied to a membership whose payment is in instalments, the whole discount code amount is applied rather than the discount code amount divided by the number of instalments.

## Solution
The issue was caused by how the form key for `civicrm_1_contribution_1_contribution_installments` was fetched, previously it was fetched from the form storage array which is un-reliable as the key is populated sometimes and at other times not populated. This PR fixes the issue by fetching the key directly from the webform node object.