### PR TITLE
RSE-78: Create webform_discount_settings table on installation

### DIFF
--- a/webform_civicrm_membership_extras.install
+++ b/webform_civicrm_membership_extras.install
@@ -2,12 +2,17 @@
 
 function webform_civicrm_membership_extras_install() {
   db_query("UPDATE {system} SET weight = 1000 WHERE name = 'webform_civicrm_membership_extras'");
+  _webform_civicrm_membershipextras_create_discount_settings_table();
 }
 
 /**
  * Creates the webform_discount_settings table
  */
 function webform_civicrm_membership_extras_update_7000() {
+  _webform_civicrm_membershipextras_create_discount_settings_table();
+}
+
+function _webform_civicrm_membershipextras_create_discount_settings_table() {
   $schema['webform_discount_settings'] = array(
     'description' => 'Discount settings for individual Webform nodes.',
     'fields' => array(


### PR DESCRIPTION
**webform_discount_settings**  was only getting creating when upgrading the module but not when installing it, this PR fixes that so the table get both created upon upgrade or installation.