### PR TITLE
BASWSPRT-74: Fixed 'Apply discount' field is automatically added to webform component

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -453,7 +453,7 @@ function _webform_civicrm_discount_settings_submit(&$form, &$form_state) {
   $wf_me_discount_settings->save($nid, $enable_discount_status);
 
   $node = node_load($nid);
-  if (!_webform_has_discount_component_attached($node)) {
+  if ($enable_discount_status == TRUE && !_webform_has_discount_component_attached($node)) {
     _webform_discount_civicrm_create_discount_component($node);
   }
 }


### PR DESCRIPTION
## Overview
When editing webform  the ‘apply discount’ field is automatically added into the list of webform components every time a webform is saved even the Discounts integration is not enabled. 

## Before
Field 'apply discount' is always created when webform is saved.

![BASW-issue](https://user-images.githubusercontent.com/208713/66850967-b9db2300-ef71-11e9-896b-d6a811e2e9e0.gif)

## After
Field 'apply discount' is only created when Discount Enabled is ticked. 

![BASW-issue-fixed](https://user-images.githubusercontent.com/208713/66850979-bd6eaa00-ef71-11e9-931c-6f22c7228faa.gif)

