### PR TITLE
MAE-153: Prevent executing apiWrappers hook for API v4

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -35,6 +35,11 @@ function webform_civicrm_membership_extras_webform_submission_insert($node, $sub
  * @param $apiRequest
  */
 function webform_civicrm_membership_extras_civicrm_apiWrappers(&$wrappers, $apiRequest) {
+  // prevent executing this for API v4 calls
+  if (is_object($apiRequest)) {
+    return;
+  }
+
   // Add custom civicrm api wrapper to alter line item price
   $wrappers[] = new wf_me_discount_civicrm_apiwrapper();
 }


### PR DESCRIPTION
## Problem

The issue originally appeared and fixed  in the prospect extension here : https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/44

implementing apiWrappers hook 2nd argument **$apiRequest** for v3 calls except an array where for v4 expect an object which might cause issues depending on the implementation of the hook.

## Solution

If the **$apiRequest** is an object then it means it is an API v4 call and then we return early 