### PR TITLE
CGP-1508: Populate Recur line items when adding an auto-renewed membership(s)

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -18,6 +18,10 @@ function webform_civicrm_membership_extras_webform_submission_insert($node, $sub
 
   if (!empty($contributionRecurId)) {
     civicrm_initialize();
+
+    $lineItemCreator = new CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator($contributionRecurId);
+    $lineItemCreator->create();
+
     $installmentsHandler = new CRM_MembershipExtras_Service_MembershipInstallmentsHandler($contributionRecurId);
     $installmentsHandler->createRemainingInstalmentContributionsUpfront();
   }


### PR DESCRIPTION
## Before 

Submitting a webform that is configured to create an auto-renewed membership(s) is not creating the recur line items (the records in membership_subscription_lines table) which result in having empty screen when visiting "manage installments" on CiviCRM

![beee](https://user-images.githubusercontent.com/6275540/70271542-45717300-17af-11ea-8d0b-5ba9d9ddb4ed.gif)

## After

Doing the above will create the recur line items and "manage installments" page contain line items on both current and next period tabs : 

![afff](https://user-images.githubusercontent.com/6275540/70271621-6f2a9a00-17af-11ea-9bf9-065c09925289.gif)


This was done by updating webform_civicrm_membership_extras_webform_submission_insert() hook which runs after submitting the webform to to call CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator::create() which handle the creation of the recur line items for the recur contribution.