### PR TITLE
BASWSPRT-73: Fix Applying Discount Code to Membership Contribution

### DIFF
--- a/includes/wf_me_cividiscount_ext_helper.inc
+++ b/includes/wf_me_cividiscount_ext_helper.inc
@@ -7,6 +7,13 @@
 class wf_me_cividiscount_ext_helper {
 
   /**
+   * wf_me_cividiscount_ext_helper constructor.
+   */
+  public function __construct() {
+    civicrm_initialize();
+  }
+
+  /**
    * Checks whether CiviDiscount extension is enabled or not.
    *
    * @return bool


### PR DESCRIPTION
## Overview
When trying to signup new membership using Webform and after applying discount count code, getting 'AJAX HTTP Result code: 500' and unable to create membership with discount.

## Before
Fatal error was being thrown when trying to apply discount code as CiviCRM was not initialized and a call to civicrm_api3() method triggered a "Call to undefined function" exception.

## After
Initialized CiviCRM on class constructor.