### PR TITLE
MAE-175: Ensure that the auto-renew flag is set correctly after webform submission

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -20,6 +20,7 @@ function webform_civicrm_membership_extras_webform_submission_insert($node, $sub
     civicrm_initialize();
 
     $lineItemCreator = new CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator($contributionRecurId);
+    $lineItemCreator->forceAutorenewalFlagCalculation();
     $lineItemCreator->create();
 
     $installmentsHandler = new CRM_MembershipExtras_Service_MembershipInstallmentsHandler($contributionRecurId);

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -19,12 +19,8 @@ function webform_civicrm_membership_extras_webform_submission_insert($node, $sub
   if (!empty($contributionRecurId)) {
     civicrm_initialize();
 
-    $lineItemCreator = new CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator($contributionRecurId);
-    $lineItemCreator->forceAutorenewalFlagCalculation();
-    $lineItemCreator->create();
-
-    $installmentsHandler = new CRM_MembershipExtras_Service_MembershipInstallmentsHandler($contributionRecurId);
-    $installmentsHandler->createRemainingInstalmentContributionsUpfront();
+    CRM_MembershipExtras_WebformAPI_RecurringContributionLineItemCreator::create($contributionRecurId);
+    CRM_MembershipExtras_WebformAPI_UpfrontContributionsCreator::create($contributionRecurId);
   }
 
   $discountCodeDetails = _membershipextras_getSubmittedDiscountCodeDetails($node, $submission);


### PR DESCRIPTION
## Problem

If you submitted a webform that is configured with multi-memberships where only some of then are configured to be auto-renewed, then in manage installments screen all of them will appear to be an auto-renewal memberships and just the ones you configured to be auto-renewal. Even add-on contributions will appear as auto-renew though auto-renewal for add-on contribution is not supported on webforms.

![2019-12-24 19_17_00-Membership signup-DD _ m7civi519](https://user-images.githubusercontent.com/6275540/71421205-5bb57500-2671-11ea-8310-1e65d088980c.png)

![2019-12-24 19_18_55-fdskods0@ad com fdskods0@ad com _ m7civi519](https://user-images.githubusercontent.com/6275540/71421232-80a9e800-2671-11ea-91c5-3ad063312f2c.png)


## Solution

The issue happen because the membershipextras extension always set the auto_renew flag on the recur contribution line items to TRUE without looking if the membership is an auto-renewal membership or not, I changed this in this PR so the auto_renew flag on the recur line item get calculated and set based if the membership is an auto-renewal membership or not. 
I achieved that by creating a new method inside inside membershipextras extension CRM_MembershipExtras_Ho
ok_PostProcess_RecurringContributionLineItemCreator::forceAutorenewalFlagCalculation() that if called will force the class to check if the membership is an auto-renewal or not.

![2019-12-24 19_24_36-daadsdas@Adc om daadsdas@Adc om _ m7civi519](https://user-images.githubusercontent.com/6275540/71421362-4ab93380-2672-11ea-861c-e87e748eb76a.png)


The reason for calling this method for webform only instead of always trying calculate the auto_renew flag, is that it might break how it work for other places, for example if you are creating a membership in CiviCRM using the membership creation form, and if you are using price-field with more than one membership and you set the "auto renew" option for it, then non of these membership will be an auto-renew inside manage installments screen and the that's because the recur line items are created before assigning the recur contribution ID to the membership so it will be treated as a normal membership instead of an auto-renewal membership which is different from the weborms where the recur contribution ID is set during the creation of the membership which make it possible to check if it an auto-renewal or not.


## Update 1
I created a new space that contains the logic responsble for the interaction between this module and membershipextras extension, we call it WebformAPI and can be found inside this directory inside the membershipextras extension `CRM/MembershipExtras/WebformAPI`, for now it contain two classes; One that handle the creation of the recur line items and one that handle the creation of upfront contributions.