### PR TITLE
MAE-186: Fix Error When Removing Fields From Webform

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -67,6 +67,10 @@ function webform_civicrm_membership_extras_form_alter(&$form, &$form_state, $for
  * @param string $form_id
  */
 function wf_me_wf_crm_configure_form_alter_handler(&$form, &$form_state, $form_id) {
+  if (!isset($form['contribution'])) {
+    return;
+  }
+
   $wf_me_cividiscount_helper = new wf_me_cividiscount_ext_helper();
   $wf_me_discount_settings = new wf_me_discount_settings();
 

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -72,20 +72,21 @@ function wf_me_wf_crm_configure_form_alter_handler(&$form, &$form_state, $form_i
   }
 
   $wf_me_cividiscount_helper = new wf_me_cividiscount_ext_helper();
-  $wf_me_discount_settings = new wf_me_discount_settings();
-
-  if ($wf_me_cividiscount_helper->isEnabled()) {
-    $nid = $form_state['storage']['nid'];
-    $discount_status = $wf_me_discount_settings->getDiscountStatus($nid);
-
-    $form['contribution']['wcm_enable_discount'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Enable Discounts'),
-      '#default_value' => $discount_status ,
-      '#description' => 'When adding this field to the webform, please make sure it is also added to the CiviCRM contribution page'
-    );
-    $form['#submit'][] = '_webform_civicrm_discount_settings_submit';
+  if (!$wf_me_cividiscount_helper->isEnabled()) {
+    return;
   }
+
+  $wf_me_discount_settings = new wf_me_discount_settings();
+  $nid = $form_state['storage']['nid'];
+  $discount_status = $wf_me_discount_settings->getDiscountStatus($nid);
+
+  $form['contribution']['wcm_enable_discount'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable Discounts'),
+    '#default_value' => $discount_status ,
+    '#description' => 'When adding this field to the webform, please make sure it is also added to the CiviCRM contribution page'
+  );
+  $form['#submit'][] = '_webform_civicrm_discount_settings_submit';
 }
 
 /**


### PR DESCRIPTION
## Overview
When fields are being removed from a webform, a confirmation message is shown asking the user to verify he in fact wants to remove those fields. This screen is showing the 'enable discounts' checkbox, when it shouldn't. Furthermore, when user accepts to remove the fields, an error is shown.

> DOException: SQLSTATE[23000]: Integrity constraint violation: 1048 
Column 'nid' cannot be null: INSERT INTO {webform_discount_settings} (nid, enabled) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1); Array
( [:db_insert_placeholder_0] => [:db_insert_placeholder_1] => 0 ) in wf_me_discount_settings->create() (line 58 of

## Before
The screen to show the confirmation message when removing fields is actually the same form as the one where you configure what CiviCRM fields you want to add to a webform, except it shows different things. Thus, the 'enable discounts' checkbox is added to both visualizations, as it is the same form.

## After
Added check so 'enable discounts' is only shown if the tab for contributions is being shown in the form.