### PR TITLE
BASWSPRT-125: Fix Contribution Amounts When Applying Discounts

### DIFF
--- a/includes/wf_me_discount_amount_helper.inc
+++ b/includes/wf_me_discount_amount_helper.inc
@@ -151,9 +151,7 @@ class wf_me_discount_amount_helper {
    * @return float|int
    */
   private function getFixedDiscountedAmount($lineItemTotal, $discountCodeAmount, $lineItemsToDiscountCount = 1) {
-    $numberOfInstallments = $this->getNumberOfInstallments();
-    $discountAmountPerInstallment = $discountCodeAmount/$numberOfInstallments;
-    $discountAmountPerLineItem = $discountAmountPerInstallment/$lineItemsToDiscountCount;
+    $discountAmountPerLineItem = $discountCodeAmount/$lineItemsToDiscountCount;
     $fixedDiscountedAmount = $lineItemTotal - $discountAmountPerLineItem;
 
     return $fixedDiscountedAmount > 0 ? $fixedDiscountedAmount : 0;
@@ -193,33 +191,4 @@ class wf_me_discount_amount_helper {
     return FALSE;
   }
 
-  /**
-   * Gets the number of installments for the membership payments.
-   * This is useful in eventually calculating how the discount will
-   * be applied to the membership payment.
-   *
-   * @return int
-   */
-  public function getNumberOfInstallments() {
-    if (!$this->numberOfInstallments) {
-      $webformComponents = $this->formStorage['component_tree']['children'];
-      $installments_key = '';
-      $installments = '';
-      foreach ($webformComponents as $key => $value) {
-        if (strpos($value['form_key'], 'contribution_installments') !== FALSE) {
-          $installments_key = $key;
-          break;
-        }
-      }
-
-      if ($installments_key) {
-        $installments = $this->formStorage['submitted'][$installments_key];
-      }
-
-      $this->numberOfInstallments = $installments ? $installments : 1;
-    }
-
-
-    return $this->numberOfInstallments;
-  }
 }

--- a/includes/wf_me_discount_amount_helper.inc
+++ b/includes/wf_me_discount_amount_helper.inc
@@ -182,8 +182,12 @@ class wf_me_discount_amount_helper {
    * @return bool
    */
   private function getLineItemMembershipIdForDiscount($membershipNamesForDiscount, $lineItemLabel) {
+    // Webform civicrm module uses the (membership type name + ": " + contact name) formula as a label
+    // for any membership line item, so we split here the part before the ": " to get the membership type name
+    $membershipNameFromLineItemLabel = substr($lineItemLabel, 0, strpos($lineItemLabel, ': '));
+
     foreach ($membershipNamesForDiscount as $id => $name) {
-      if (strpos($lineItemLabel, $name) !== FALSE) {
+      if (strpos($name, $membershipNameFromLineItemLabel) !== FALSE) {
         return $id;
       }
     }

--- a/includes/wf_me_discount_amount_helper.inc
+++ b/includes/wf_me_discount_amount_helper.inc
@@ -101,24 +101,26 @@ class wf_me_discount_amount_helper {
    * @return array
    */
   private function adjustLineItems($lineItems, $membershipNamesForDiscount, $discountCodeDetails) {
+    $lineItemsToDiscountCount = $this->getLineItemsToDiscountCount($lineItems, $membershipNamesForDiscount);
     $totalAmount = 0;
     foreach ($lineItems as $key => $lineItem) {
       $membershipID = $this->getLineItemMembershipIdForDiscount($membershipNamesForDiscount, $lineItem['label']);
       if ($membershipID) {
         $discountedAmount = 0;
         if ($discountCodeDetails['amount_type'] == self::WEBFORM_DISCOUNT_FIXED_AMOUNT) {
-          $discountedAmount = $this->getFixedDiscountedAmount($lineItem['line_total'], $discountCodeDetails['amount']);
+          $discountedAmount = $this->getFixedDiscountedAmount($lineItem['line_total'], $discountCodeDetails['amount'], $lineItemsToDiscountCount);
+          $amountDiscounted = $discountCodeDetails['amount'] / $lineItemsToDiscountCount;
         }
         elseif ($discountCodeDetails['amount_type'] == self::WEBFORM_DISCOUNT_PERCENTAGE_AMOUNT) {
           $discountedAmount = $this->getPercentageDiscountedAmount($lineItem['line_total'], $discountCodeDetails['amount']);
+          $amountDiscounted = $lineItem['line_total'] - $discountedAmount;
         }
 
-        $amountDiscounted = $lineItem['line_total'] - $discountedAmount;
         $totalAmount += $discountedAmount;
         $lineItems[$key]['unit_price'] = number_format((float) $discountedAmount, 2, '.', '');
         $lineItems[$key]['line_total'] = $discountedAmount;
         $lineItems[$key]['discount_applied'] = 1;
-        $lineItems[$key]['discounted_amount'] = number_format((float) $amountDiscounted, 2, '.', '');;
+        $lineItems[$key]['discounted_amount'] = number_format((float) $amountDiscounted, 2, '.', '');
         $lineItems[$key]['membership_type_id'] = $membershipID;
         $lineItems[$key]['original_amount'] = $lineItem['line_total'];
         $lineItems[$key]['discount_code_amount'] = $discountCodeDetails['amount'];
@@ -128,17 +130,31 @@ class wf_me_discount_amount_helper {
     return ['line_items' => $lineItems, 'total_amount' => $totalAmount];
   }
 
+  private function getLineItemsToDiscountCount($lineItems, $membershipNamesForDiscount) {
+    $lineItemsToDiscountCount = 0;
+    foreach ($lineItems as $key => $lineItem) {
+      $membershipID = $this->getLineItemMembershipIdForDiscount($membershipNamesForDiscount, $lineItem['label']);
+      if ($membershipID) {
+        $lineItemsToDiscountCount++;
+      }
+    }
+
+    return $lineItemsToDiscountCount;
+  }
+
   /**
    * Returns the amount for line total after discount has been deducted for fixed discount.
    *
    * @param mixed $lineItemTotal
    * @param mixed $discountCodeAmount
-   *
+   * @param mixed $lineItemsToDiscountCount
    * @return float|int
    */
-  private function getFixedDiscountedAmount($lineItemTotal, $discountCodeAmount) {
+  private function getFixedDiscountedAmount($lineItemTotal, $discountCodeAmount, $lineItemsToDiscountCount = 1) {
     $numberOfInstallments = $this->getNumberOfInstallments();
-    $fixedDiscountedAmount = $lineItemTotal - ($discountCodeAmount/$numberOfInstallments);
+    $discountAmountPerInstallment = $discountCodeAmount/$numberOfInstallments;
+    $discountAmountPerLineItem = $discountAmountPerInstallment/$lineItemsToDiscountCount;
+    $fixedDiscountedAmount = $lineItemTotal - $discountAmountPerLineItem;
 
     return $fixedDiscountedAmount > 0 ? $fixedDiscountedAmount : 0;
   }

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -206,24 +206,18 @@ function _set_discount_code_status_in_session($status) {
 
 /**
  * Custom function to add webform discount context to session.
+ *
  * This is used in Webform_Discount_Civicrm_APIWrapper to alter line item price
  * when returning items that have already been discounted.
- * For contribution in installments, the discounted amount for the line item need
- * to be multiplied by the number of installments because in the tallyLineItems
- * function of webform_civicrm module, the amount is divided by the number of installments
- * so if we don't make sure the total amount is added for the line item here, the resulting
- * amount is going to be less than expected.
  *
  * @param array $form
  * @param array $form_state
  */
 function _set_discounted_membership_items_in_session($form, &$form_state) {
-  $wf_me_discount_amount_helper = new wf_me_discount_amount_helper($form_state['storage']);
-  $number_of_installments = $wf_me_discount_amount_helper->getNumberOfInstallments();
   $membership_type_added = array();
   foreach ($form_state['line_items'] as $item) {
     if (isset($item['membership_type_id'])) {
-      $membership_type_added[$item['membership_type_id']] = $item['unit_price'] * $number_of_installments;
+      $membership_type_added[$item['membership_type_id']] = $item['unit_price'];
     }
   }
 


### PR DESCRIPTION
## Overview
Discounted price is not shown on Contribution page, if membership is created using webform with Payment plan. 

Here Membership fee for Standard is £50 and including tax is £60

a) Membership Signup- 2 Installments-50% Discount is applied

Contribution Screen: Discounted price is not shown, instead original price without 50% discount tax is displayed. It should be £15.00 for 2 installments.

## Before
Discounted price was being multiplied by number of installments and stored to session, so that then when calculating the price of each installment the system would take this price stored in session and divide it by the number of installments. Thus, the full discounted prices was being used for each installment, instead of it being divided among all installments. On 50% discount, and 2 installments, the discount seemed to not be applied, as the discount and the division per installment would cancel out.

## After
Stored discounted price in session and let system later divide the full discounted price to calculate the amount for each installment.