### PR TITLE
MAE-385: Bump version to 3.0.0

### DIFF
--- a/webform_civicrm_membership_extras.info
+++ b/webform_civicrm_membership_extras.info
@@ -1,6 +1,6 @@
 name = Webform CiviCRM Membership Extras
 description = Support module for uk.co.compucorp.membershipextras that handle the creation of upfront contributions after submitting a civicrm webform, CiviDiscount integration and more.
-version = 7.x-2.4
+version = 7.x-3.0
 dependencies[] = webform_civicrm
 package = MembershipExtras
 core = 7.x


### PR DESCRIPTION
## Overview

This PR is to bump version 3.0.0 for webform civcirm membrship extras module for ME v3 release. 