### PR TITLE
MAE-411: Bump version to 7.x-4.0

### DIFF
--- a/webform_civicrm_membership_extras.info
+++ b/webform_civicrm_membership_extras.info
@@ -1,6 +1,6 @@
 name = Webform CiviCRM Membership Extras
 description = Support module for uk.co.compucorp.membershipextras that handle the creation of upfront contributions after submitting a civicrm webform, CiviDiscount integration and more.
-version = 7.x-3.0
+version = 7.x-4.0
 dependencies[] = webform_civicrm
 package = MembershipExtras
 core = 7.x


### PR DESCRIPTION
## Overview
Bumping version to 7.x-4.0 as part of Membershipextras suite version 4.0.0 release.