### PR TITLE
CPS-422: Fix Query Built to Count Cividiscount Settings

### DIFF
--- a/includes/wf_me_discount_settings.inc
+++ b/includes/wf_me_discount_settings.inc
@@ -15,7 +15,7 @@ class wf_me_discount_settings {
    */
   public function save($nid, $discountStatus) {
     $query = db_select('webform_discount_settings')
-      ->fields('nid')
+      ->fields('webform_discount_settings', ['nid'])
       ->condition('nid', $nid);
     $numberOfRows = $query->countQuery()->execute()->fetchField();
 


### PR DESCRIPTION
## Overview
Saving a webform results in an error.

- Create a new webform
- Go to Civicrm tab
- Check Enable Civicrm Processsing
- Click on “Save Settings”
- Error is thrown

![image](https://user-images.githubusercontent.com/21999940/102113082-98402a80-3e06-11eb-8249-9bf53d4cc2d0.png)

## Before
There is a query used by wf_me_discount_settings class to determine if there are any settings stored in the discount settings table (webform_discount_settings). The query is built using Drupal's core DB management classes, but they were being used wrongly. Specifically, the call to the `SelectQuery::fields()` expects two parameters, the table alias, and an array of field names. We were only passing one parameter, the name of the field we expected to be returned.

https://git.drupalcode.org/project/drupal/-/blob/7.x/includes/database/select.inc#L1316-1330

## After
Made the call to `SelectQuery::fields()`, passing both table alias and array of fields to be returned.