### PR TITLE
MAE-477: Manage payment plan active status on webform submission

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -21,6 +21,7 @@ function webform_civicrm_membership_extras_webform_submission_insert($node, $sub
 
     CRM_MembershipExtras_WebformAPI_RecurringContributionLineItemCreator::create($contributionRecurId);
     CRM_MembershipExtras_WebformAPI_UpfrontContributionsCreator::create($contributionRecurId);
+    CRM_MembershipExtras_WebformAPI_PaymentPlanActivation::activateOnlyLast($contributionRecurId);
   }
 
   $discountCodeDetails = _membershipextras_getSubmittedDiscountCodeDetails($node, $submission);


### PR DESCRIPTION
This is a continuation of the work that is done here: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/355

it basically ensures that the "Is active" field is set correctly when creating or renewing payment plan membership using webforms using the API created in the above PR.