### PR TITLE
BASW-756: Add hook to allow changing things before creating upfront installments

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -20,6 +20,7 @@ function webform_civicrm_membership_extras_webform_submission_insert($node, $sub
     civicrm_initialize();
 
     CRM_MembershipExtras_WebformAPI_RecurringContributionLineItemCreator::create($contributionRecurId);
+    module_invoke_all('webformmembershipextras_preCreatingUpfrontContributions', $node, $contributionRecurId);
     CRM_MembershipExtras_WebformAPI_UpfrontContributionsCreator::create($contributionRecurId);
     CRM_MembershipExtras_WebformAPI_PaymentPlanActivation::activateOnlyLast($contributionRecurId);
   }


### PR DESCRIPTION
## Overview

This PR adds a hook that is dispatched before creating the payment plan remaining upfront installments, which allows other modules to alter any data needed before creating the rest of the installments.

The main reason for creating it is to allow the "webform-manualdd" to attach the mandate to the payment plan and to the installments, and to allow altering the dates for the payment plan and the first installment in case a direct debit payment was made, more info can be found in this PR: https://github.com/compucorp/webform-manualdd/pull/24