### PR TITLE
MAE-554: Add support for pro rata calculations.

### DIFF
--- a/includes/wf_me_prorated_billing_apiwrapper.inc
+++ b/includes/wf_me_prorated_billing_apiwrapper.inc
@@ -1,0 +1,36 @@
+<?php
+
+class wf_me_prorated_billing_apiwrapper implements API_Wrapper {
+  /**
+   * {@inheritdoc}
+   */
+  public function fromApiInput($apiRequest) {
+    return $apiRequest;
+  }
+
+  /**
+   * This method basically modifies the response for the get method of the
+   * membership_type.get API to allow the minimum fee to be set correctly for
+   * pro rated memberships based on data stored in session.
+   *
+   * @param array $apiRequest
+   * @param array $result
+   *
+   * @return array
+   */
+  public function toApiOutput($apiRequest, $result) {
+    if ($apiRequest['entity'] == 'MembershipType' && $apiRequest['action'] == 'get') {
+      // is 'webform_prorated_billing:is_enabled' key is true, alter api results to have discounted prices
+      if (!empty($_SESSION['webform_prorated_billing']['is_enabled'])) {
+        $membership_types = $_SESSION['webform_prorated_billing']['membership_types'];
+        foreach ($membership_types as $membership_type_id => $price) {
+          $result['values'][$membership_type_id]['minimum_fee'] = $price;
+        }
+      }
+      // unset context so from next call discount wont be set in results
+      unset($_SESSION['webform_prorated_billing']);
+    }
+
+    return $result;
+  }
+}

--- a/includes/wf_me_prorated_billing_apiwrapper.inc
+++ b/includes/wf_me_prorated_billing_apiwrapper.inc
@@ -19,6 +19,13 @@ class wf_me_prorated_billing_apiwrapper implements API_Wrapper {
    * @return array
    */
   public function toApiOutput($apiRequest, $result) {
+    // if a 'webform_discount_submit' context is present, skip altering the
+    // result because the 'wf_me_discount_civicrm_apiwrapper' class will alter
+    // it with discounted prorated prices.
+    if (isset($_SESSION['webform_discount_submit'])) {
+      return $result;
+    }
+
     if ($apiRequest['entity'] == 'MembershipType' && $apiRequest['action'] == 'get') {
       // is 'webform_prorated_billing:is_enabled' key is true, alter api results to have discounted prices
       if (!empty($_SESSION['webform_prorated_billing']['is_enabled'])) {
@@ -27,8 +34,6 @@ class wf_me_prorated_billing_apiwrapper implements API_Wrapper {
           $result['values'][$membership_type_id]['minimum_fee'] = $price;
         }
       }
-      // unset context so from next call discount wont be set in results
-      unset($_SESSION['webform_prorated_billing']);
     }
 
     return $result;

--- a/includes/wf_me_prorated_billing_apiwrapper.inc
+++ b/includes/wf_me_prorated_billing_apiwrapper.inc
@@ -22,7 +22,7 @@ class wf_me_prorated_billing_apiwrapper implements API_Wrapper {
     // if a 'webform_discount_submit' context is present, skip altering the
     // result because the 'wf_me_discount_civicrm_apiwrapper' class will alter
     // it with discounted prorated prices.
-    if (isset($_SESSION['webform_discount_submit'])) {
+    if (!empty($_SESSION['webform_discount_submit']['membership_types'])) {
       return $result;
     }
 

--- a/webform_civicrm_membership_extras.info
+++ b/webform_civicrm_membership_extras.info
@@ -11,3 +11,4 @@ files[] = includes/wf_me_discount_settings.inc
 files[] = includes/wf_me_discount_code_validator.inc
 files[] = includes/wf_me_discount_amount_helper.inc
 files[] = includes/wf_me_discount_civicrm_apiwrapper.inc
+files[] = includes/wf_me_prorated_billing_apiwrapper.inc

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -45,6 +45,7 @@ function webform_civicrm_membership_extras_civicrm_apiWrappers(&$wrappers, $apiR
 
   // Add custom civicrm api wrapper to alter line item price
   $wrappers[] = new wf_me_discount_civicrm_apiwrapper();
+  $wrappers[] = new wf_me_prorated_billing_apiwrapper();
 }
 
 
@@ -697,6 +698,42 @@ function _webform_civicrm_membership_extras_prorated_billing_form_alter_handler(
   }
 
   $form['#validate'][] = '_webform_civicrm_membership_extras_update_the_prorated_membership_items';
+  $form['#validate'][] = '_webform_civicrm_membership_extras_set_prorated_membership_items_in_session';
+
+  // The `wf_me_prorated_billing_apiwrapper` modifies the response for the get
+  // method of the membership_type.get API to allow the minimum fee to be set
+  // correctly for prorated memberships based on data stored in session.
+  // This behavior is by default disabled and can only be enabled by calling
+  // the method `_webform_civicrm_membership_extras_enable_prorated_billing`.
+  // If the user reached the last step , reviewed the confirmation page
+  // details and clicked submit, the
+  // `_webform_civicrm_membership_extras_enable_prorated_billing` function will
+  // be called to allow wf_me_prorated_billing_apiwrapper to replace membership
+  // fee with the new adjusted value that was saved in the session.
+  // After webform_civicrm extension have done its work to save the prorated
+  // membership fees, the
+  // `_webform_civicrm_membership_extras_disable_prorated_billing` function
+  // will be called to stop replacing the membership fee with the new adjusted
+  // value that was saved in the session.
+  // The _webform_civicrm_membership_extras_clear_prorated_billing_related_data
+  // function will delete any data stored in the session.
+  $page_num = $form['details']['page_num']['#value'];
+  $page_count = $form['details']['page_count']['#value'];
+  $isWebformConfirmationPage = $page_num === $page_count;
+  if ($isWebformConfirmationPage) {
+    $validate_callbacks = $form['#validate'];
+    $form['#validate'] = array();
+    foreach ($validate_callbacks as $validate_callback) {
+      if ($validate_callback == 'wf_crm_validate') {
+        $form['#validate'][] = '_webform_civicrm_membership_extras_enable_prorated_billing';
+        $form['#validate'][] = $validate_callback;
+        $form['#validate'][] = '_webform_civicrm_membership_extras_disable_prorated_billing';
+        $form['#validate'][] = '_webform_civicrm_membership_extras_clear_prorated_billing_related_data';
+      } else {
+        $form['#validate'][] = $validate_callback;
+      }
+    }
+  }
 }
 
 /**
@@ -939,6 +976,62 @@ function _webform_civicrm_membership_extras_is_prorated_billing_enabled($form, &
   }
 
   return TRUE;
+}
+
+/**
+ * Adds webform prorated membership items to session.
+ *
+ * This is used in wf_me_prorated_billing_apiwrapper to alter line item price
+ * when returning items that have already been prorated.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function _webform_civicrm_membership_extras_set_prorated_membership_items_in_session($form, &$form_state) {
+  $membership_type_added = array();
+  foreach ($form_state['civicrm']['line_items'] as $item) {
+    if (isset($item['membership_type_id'])) {
+      $membership_type_added[$item['membership_type_id']] = $item['unit_price'];
+    }
+  }
+
+  $_SESSION['webform_prorated_billing']['membership_types'] = $membership_type_added;
+}
+
+/**
+ * Enables prorated billing.
+ *
+ * This is used in wf_me_prorated_billing_apiwrapper to alter line item price
+ * when returning items that have already been prorated.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function _webform_civicrm_membership_extras_enable_prorated_billing($line_items) {
+  $_SESSION['webform_prorated_billing']['is_enabled'] = TRUE;
+}
+
+/**
+ * Disables prorated billing.
+ *
+ * This is used in wf_me_prorated_billing_apiwrapper to alter line item price
+ * when returning items that have already been prorated.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function _webform_civicrm_membership_extras_disable_prorated_billing($line_items) {
+  $_SESSION['webform_prorated_billing']['is_enabled'] = FALSE;
+}
+
+/**
+ * Clears general pro rata related data stored in form state and in session.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function _webform_civicrm_membership_extras_clear_prorated_billing_related_data($form, &$form_state) {
+  unset($_SESSION['webform_prorated_billing']);
 }
 
 function _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, $form_key) {

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -45,7 +45,14 @@ function webform_civicrm_membership_extras_civicrm_apiWrappers(&$wrappers, $apiR
 
   // Add custom civicrm api wrapper to alter line item price
   $wrappers[] = new wf_me_discount_civicrm_apiwrapper();
-  $wrappers[] = new wf_me_prorated_billing_apiwrapper();
+
+  // The deployment failed because the following class wasn't loaded.
+  // I think it is related to the cache wasn't cleared and hence no re-read
+  // for the info file to load the following file.
+  if (class_exists('wf_me_prorated_billing_apiwrapper')) {
+    $wrappers[] = new wf_me_prorated_billing_apiwrapper();
+  }
+
 }
 
 

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -695,6 +695,26 @@ function _webform_civicrm_membership_extras_prorated_billing_form_alter_handler(
   if (!_webform_civicrm_membership_extras_is_prorated_billing_enabled($form, $form_state, $membershipTypes)) {
     return;
   }
+
+  $form['#validate'][] = '_webform_civicrm_membership_extras_update_the_prorated_membership_items';
+}
+
+/**
+ * Gets the instalmentAmountCalculator.
+ *
+ * @param object $membershipType
+ * @param array $membershipDates
+ */
+function _webform_civicrm_membership_extras_get_instalment_amount_calculator($membershipType, $membershipDates) {
+  $calculator = new CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator([$membershipType]);
+  $calculator->setStartDate(new DateTime($membershipDates['start_date']));
+  $calculator->setEndDate(new DateTime($membershipDates['end_date']));
+  $calculator->setJoinDate(new DateTime($membershipDates['join_date']));
+
+  $instalmentAmountCalculator = new CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator($calculator);
+  $instalmentAmountCalculator->getCalculator()->calculate();
+
+  return $instalmentAmountCalculator;
 }
 
 /**
@@ -727,6 +747,64 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
   }
 
   return $membership_type_added;
+}
+
+/**
+ * Gets the membership dates.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param array $membershipTypes
+ */
+function _webform_civicrm_membership_extras_get_membership_dates(&$form, &$form_state, $membershipTypes) {
+  foreach ($membershipTypes as $key => $membershipType) {
+    $membershipTypeDatesCalculator = new CRM_MembershipExtras_Service_MembershipTypeDatesCalculator();
+    $membership_dates_added[$key] = $membershipTypeDatesCalculator->getDatesForMembershipType(
+      $membershipType->id, NULL, NULL, NULL
+    );
+
+    // Sets the start date to NULL to use today as the start date.
+    $membership_dates_added[$key]['start_date'] = NULL;
+  }
+
+  return $membership_dates_added;
+}
+
+/**
+ * Calculates the prorated membership items.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function _webform_civicrm_membership_extras_update_the_prorated_membership_items($form, &$form_state) {
+  $membershipTypes = _webform_civicrm_membership_extras_get_membership_types($form, $form_state);
+
+  $components = $form['#node']->webform['components'];
+  $membershipNamesAndKeysMap = [];
+  foreach ($membershipTypes as $key => $membershipType) {
+    $membership_number = explode('_membership_membership_type_id', $components[$key]['form_key'])[0];
+    $membershipNamesAndKeysMap[$membership_number] = $key;
+  }
+
+  $membershipDates = _webform_civicrm_membership_extras_get_membership_dates($form, $form_state, $membershipTypes);
+  $line_items = &$form_state['civicrm']['line_items'];
+
+  // adjust the lineitems
+  $instalmentCount = 1;
+  foreach ($membershipTypes as $key => $membershipType) {
+    $instalmentAmountCalculator = _webform_civicrm_membership_extras_get_instalment_amount_calculator($membershipTypes[$key], $membershipDates[$key]);
+    $instalmentAmount = $instalmentAmountCalculator->calculateInstalmentAmount($instalmentCount);
+    $instalmentLineItems = $instalmentAmount->getLineItems();
+
+    foreach($line_items as $line_item_key => $item) {
+      if (isset($membershipNamesAndKeysMap[$item['element']]) && $membershipNamesAndKeysMap[$item['element']] === $key) {
+        $line_items[$line_item_key]['unit_price'] = $instalmentLineItems[0]->getUnitPrice();
+        $line_items[$line_item_key]['line_total'] = $instalmentLineItems[0]->getTotalAmount() - $instalmentLineItems[0]->getTaxAmount();
+        $line_items[$line_item_key]['tax_amount'] = $instalmentLineItems[0]->getTaxAmount();
+        $line_items[$line_item_key]['membership_type_id'] = $membershipTypes[$key]->id;
+      }
+    }
+  }
 }
 
 /**

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -772,14 +772,22 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
   foreach ($components as $key => $component) {
     // use array for membership_type ids because checkbox input allows mult-value.
     $membership_type_ids = [];
+
+    // First, try to get the $membership_type_ids from the input array.
     foreach($form_state['input']['submitted'] as $fieldset) {
       if (!empty($fieldset[$component['form_key']])) {
         $membership_type_ids = $fieldset[$component['form_key']];
-        if (!is_array($membership_type_ids)) {
-          $membership_type_ids = [$membership_type_ids];
-        }
         break;
       }
+    }
+
+    // Second, try to get the $membership_type_ids from the storage array if it
+    // was populated, which means this is another page or it is an ajax request
+    // for applying the discoumt code.
+    $membership_type_ids = $form_state['storage']['submitted'][$key] ?? $membership_type_ids;
+
+    if (!is_array($membership_type_ids)) {
+      $membership_type_ids = [$membership_type_ids];
     }
 
     foreach($membership_type_ids as $membership_type_id) {

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -935,8 +935,11 @@ function _webform_civicrm_membership_extras_update_the_prorated_membership_items
     foreach($line_items as $line_item_key => $item) {
       if (isset($membershipNamesAndKeysMap[$item['element']]) && $membershipNamesAndKeysMap[$item['element']] === $key) {
         $line_items[$line_item_key]['unit_price'] = $instalmentLineItems[0]->getUnitPrice();
+        $line_items[$line_item_key]['unit_price'] = number_format( $line_items[$line_item_key]['unit_price'], 2, '.', '');
         $line_items[$line_item_key]['line_total'] = $instalmentLineItems[0]->getTotalAmount() - $instalmentLineItems[0]->getTaxAmount();
+        $line_items[$line_item_key]['line_total'] = (float) number_format( $line_items[$line_item_key]['line_total'], 2, '.', '');
         $line_items[$line_item_key]['tax_amount'] = $instalmentLineItems[0]->getTaxAmount();
+        $line_items[$line_item_key]['tax_amount'] = (float) number_format( $line_items[$line_item_key]['tax_amount'], 2, '.', '');
         $line_items[$line_item_key]['membership_type_id'] = $membershipTypes[$key]->id;
       }
     }

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -750,21 +750,105 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
 }
 
 /**
+ * Gets the membership dates from inputs.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param string $date_name
+ */
+function _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name(&$form, &$form_state, $date_name) {
+  $dates = [];
+  $part_of_form_key = "_membership_$date_name";
+  $components = _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, $part_of_form_key);
+  foreach ($components as $key => $component) {
+    $date = 0;
+    foreach($form_state['input']['submitted'] as $fieldset) {
+      $day = $fieldset[$component['form_key']]['day'] ?? 0;
+      $month = $fieldset[$component['form_key']]['month'] ?? 0;
+      $year = $fieldset[$component['form_key']]['year'] ?? 0;
+      if ($day && $month && $year) {
+        $date = intval($year) . "-" . intval($month) . "-" . intval($day);
+      }
+    }
+
+    if (empty($date)) {
+      continue;
+    }
+    $membership_number = explode($part_of_form_key, $component['form_key'])[0];
+    $dates[$membership_number] = $date;
+  }
+
+  return $dates;
+}
+
+/**
+ * Merges membership dates by membership form key.
+ *
+ * @param array $membership_dates_added
+ * @param array $membershipNamesAndKeysMap
+ */
+function _webform_civicrm_membership_extras_merge_membership_dates_by_membership_form_key($membership_dates_added, $membershipNamesAndKeysMap) {
+  $result = [];
+
+  foreach($membership_dates_added as $membership_date_label => $dates) {
+    foreach ($dates as $membership_number => $date) {
+      $membership_type_key = $membershipNamesAndKeysMap[$membership_number];
+      $result[$membership_type_key][$membership_date_label] = $date;
+    }
+  }
+
+  // Prefills membrship dates with NULL if the user didn't fill all the fields.
+  foreach ($result as $key => $membership_date) {
+    $result[$key]['start_date'] = $membership_date['start_date'] ?? NULL;
+    $result[$key]['end_date'] = $membership_date['end_date'] ?? NULL;
+    $result[$key]['join_date'] = $membership_date['join_date'] ?? NULL;
+  }
+
+  return $result;
+}
+
+/**
  * Gets the membership dates.
+ *
+ * If the number of terms set to be “Enter Dates Manually” then get membership
+ * dates from the form inputs if possible. If not, then get the membership
+ * dates from the membership type.
  *
  * @param array $form
  * @param array $form_state
  * @param array $membershipTypes
+ * @param array $membershipNamesAndKeysMap
  */
-function _webform_civicrm_membership_extras_get_membership_dates(&$form, &$form_state, $membershipTypes) {
+function _webform_civicrm_membership_extras_get_membership_dates(&$form, &$form_state, $membershipTypes, $membershipNamesAndKeysMap) {
+  $membership_dates_added = [
+    'start_date' => _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name($form, $form_state, 'start_date'),
+    'end_date' => _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name($form, $form_state, 'end_date'),
+    'join_date' => _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name($form, $form_state, 'join_date'),
+  ];
+
+  $membership_dates_added =
+    _webform_civicrm_membership_extras_merge_membership_dates_by_membership_form_key($membership_dates_added, $membershipNamesAndKeysMap);
+
   foreach ($membershipTypes as $key => $membershipType) {
+    $dates = $membership_dates_added[$key];
+    foreach ($dates as $label => $date) {
+      if ($dates[$label]) {
+          $dates[$label] =  new DateTime($dates[$label]);
+      }
+    }
+
     $membershipTypeDatesCalculator = new CRM_MembershipExtras_Service_MembershipTypeDatesCalculator();
     $membership_dates_added[$key] = $membershipTypeDatesCalculator->getDatesForMembershipType(
-      $membershipType->id, NULL, NULL, NULL
+      $membershipType->id,
+      $dates['start_date'],
+      $dates['end_date'],
+      $dates['join_date']
     );
 
-    // Sets the start date to NULL to use today as the start date.
-    $membership_dates_added[$key]['start_date'] = NULL;
+    // Sets the start date to NULL to use today as the start date if the user didn't fill it.
+    if (!$dates['start_date']) {
+      $membership_dates_added[$key]['start_date'] = NULL;
+    }
   }
 
   return $membership_dates_added;
@@ -786,7 +870,7 @@ function _webform_civicrm_membership_extras_update_the_prorated_membership_items
     $membershipNamesAndKeysMap[$membership_number] = $key;
   }
 
-  $membershipDates = _webform_civicrm_membership_extras_get_membership_dates($form, $form_state, $membershipTypes);
+  $membershipDates = _webform_civicrm_membership_extras_get_membership_dates($form, $form_state, $membershipTypes, $membershipNamesAndKeysMap);
   $line_items = &$form_state['civicrm']['line_items'];
 
   // adjust the lineitems

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -59,6 +59,8 @@ function webform_civicrm_membership_extras_form_alter(&$form, &$form_state, $for
   if (strpos($form_id, 'webform_client_form_') !== FALSE) {
     wf_me_webform_client_form_alter_handler($form, $form_state, $form_id);
   }
+
+  _webform_civicrm_membership_extras_prorated_billing_form_alter_handler($form, $form_state, $form_id);
 }
 
 /**
@@ -671,4 +673,120 @@ function _membershipextras_getCiviWebformPostprocessorPropertyValue($node, $prop
   $entityReflectionObject = $civiWebformPostprocessorReflection->getProperty($propertyName);
   $entityReflectionObject->setAccessible(true);
   return $entityReflectionObject->getValue($civiWebformPostprocessor);
+}
+
+/**
+ * The function that alters the `webform_client_form_WEBFORMID`  form.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param string $form_id
+ */
+function _webform_civicrm_membership_extras_prorated_billing_form_alter_handler(&$form, &$form_state, $form_id) {
+  if (strpos($form_id, 'webform_client_form_') === FALSE) {
+    return;
+  }
+
+  if (!_membershipextras_isCivicrmWebform($form['#node'])) {
+    return;
+  }
+
+  $membershipTypes = _webform_civicrm_membership_extras_get_membership_types($form, $form_state);
+  if (!_webform_civicrm_membership_extras_is_prorated_billing_enabled($form, $form_state, $membershipTypes)) {
+    return;
+  }
+}
+
+/**
+ * Gets the membership types that user has selected.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_state) {
+  $components = _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, '_membership_membership_type_id');
+  foreach ($components as $key => $component) {
+    // use array for membership_type ids because checkbox input allows mult-value.
+    $membership_type_ids = [];
+    foreach($form_state['input']['submitted'] as $fieldset) {
+      if (!empty($fieldset[$component['form_key']])) {
+        $membership_type_ids = $fieldset[$component['form_key']];
+        if (!is_array($membership_type_ids)) {
+          $membership_type_ids = [$membership_type_ids];
+        }
+        break;
+      }
+    }
+
+    foreach($membership_type_ids as $membership_type_id) {
+      if (empty($membership_type_id)) {
+        continue;
+      }
+      $membership_type_added[$key] = CRM_Member_BAO_MembershipType::findById($membership_type_id);
+    }
+  }
+
+  return $membership_type_added;
+}
+
+/**
+ * Checks whether prorated billing should be enabled or not.
+ *
+ * @param array $form
+ * @param array $form_state
+ * @param array $membershipTypes
+ *
+ * @return boolean
+ */
+function _webform_civicrm_membership_extras_is_prorated_billing_enabled($form, &$form_state, $membershipTypes) {
+  $areMembershipTypesFixed = TRUE;
+  foreach($membershipTypes as $membershipType) {
+    if($membershipType->period_type !== 'fixed') {
+      $areMembershipTypesFixed = FALSE;
+      break;
+    }
+  }
+  if (count($membershipTypes) < 1 || !$areMembershipTypesFixed) {
+    return FALSE;
+  }
+
+  $membershipSettings = $form['#node']->webform_civicrm['data']['membership'] ?? [];
+  $isNumberOfTermsIsOne = TRUE;
+  foreach($membershipSettings as $settings) {
+    foreach ($settings['membership'] as $membership_settings) {
+      if($membership_settings['num_terms'] > 1) {
+        $isNumberOfTermsIsOne = FALSE;
+         break 2;
+      }
+
+      // Don't do the pro-rata calculation if the user can manually select the
+      // number of terms.
+      if($membership_settings['num_terms'] === "") {
+        $isNumberOfTermsIsOne = FALSE;
+         break 2;
+      }
+    }
+  }
+  if (!$isNumberOfTermsIsOne) {
+    return FALSE;
+  }
+
+  $components = _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, '_membership_fee_amount');
+  if (count($components) > 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+function _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, $form_key) {
+  $components = $form['#node']->webform['components'];
+  $matched_components = [];
+  foreach ($components as $key => $component) {
+    if (strpos($component['form_key'], $form_key) !== FALSE) {
+      $matched_components[$key] = $component;
+    }
+  }
+
+  return $matched_components;
 }


### PR DESCRIPTION
   ## Overview
This PR adds pro rata calculations to fixed membership line items.

## Before
![Screenshot from 2021-07-13 16-33-45](https://user-images.githubusercontent.com/74309109/125465682-cd0a3ad0-6ab5-45ce-aa60-6a1cf55a47e2.png)

## After
![2021-07-13_16-34](https://user-images.githubusercontent.com/74309109/125465713-ba809990-1102-4aeb-a083-275fbda4d9ae.png)

If there is a discount code applied
![Screenshot from 2021-07-21 11-30-55](https://user-images.githubusercontent.com/74309109/126458180-e3df9d9c-581b-4f5f-b4a7-09cac003f097.png)


## Technical Details

First, the [ca55546](https://github.com/compucorp/webform_civicrm_membership_extras/pull/36/commits/ca55546f179a20dd9bc7849d2de81235bf7237d7) commit checks the following rules before applying the pro rata calculations :
  - Memberships are of duration type "fixed".
  - Number of terms to be "1" or "- Enter Dates Manually -"
  - Membership fee is not set manually
 
Second, the [254c56](https://github.com/compucorp/webform_civicrm_membership_extras/commit/254c56919bc58639afd4b7069cccafa873bb9eea) commit updates the prorated membership items by utilizing the validate hook so that we can adjust the line items before the alter_form hook called by [webform_civicrm.module#L87](https://github.com/colemanw/webform_civicrm/blob/7.x-5.x/webform_civicrm.module#L87) so that `webform_civicrm` can render the confirmation page with the new prorated membership items. This commit uses `FixedPeriodTypeCalculator`  && `MembershipInstalmentAmountCalculator` instead of implementing the pro rata logic again.

Third, the [965bd7](https://github.com/compucorp/webform_civicrm_membership_extras/commit/965bd7a89e5c4c9f373fba9d6b64a4c8370608c4) adds support for manually entered dates.

Fourth, the commit [0e42bd](https://github.com/compucorp/webform_civicrm_membership_extras/commit/0e42bd9a0e0a1f66dabb6a28c8f8d03667bc4b3e) push the prorated membership fees to be saved successfully in the database. It was a tricky doing it and here is the proposed approach by this commit - assuming the user has reached the last step in the form, reviewed the confirmation page details and clicked submit :
 - Always save the adjusted membership fees in the session.
 - Add the `wf_me_prorated_billing_apiwrapper` which modifies the response for the get method of the membership_type.get API to allow the minimum fee to be set correctly for prorated memberships based on data stored in session. This behavior is by default disabled and can only be enabled by calling the method `_webform_civicrm_membership_extras_enable_prorated_billing`
 - The `_webform_civicrm_membership_extras_enable_prorated_billing` function will be called to allow wf_me_prorated_billing_apiwrapper to replace membership fee with the new adjusted value that was saved in the session.
 - webform_civicrm extension will do its work to create the line items that include the prorated membership items.
 - The `_webform_civicrm_membership_extras_disable_prorated_billing` function will be called to stop replacing the membership fee with the new adjusted value that was saved in the session.
 - The `_webform_civicrm_membership_extras_clear_prorated_billing_related_data` function will delete any data stored in the session.

Fifth, the [6a66eb](https://github.com/compucorp/webform_civicrm_membership_extras/pull/36/commits/6a66eb04e483f90f8d8fa07aba9b906999365937) commit overcomes the failed deployment issue because of the missing file. The other solution is to update the deployment script to clear the cache before running the `drush rr` command.

Sixth, the [75259e](https://github.com/compucorp/webform_civicrm_membership_extras/pull/36/commits/75259ea3427f4fa741aab7dbe7eff84a293874d2) commit applies the discount code on prorated membership items.

Lastly, the [b09dfe](https://github.com/compucorp/webform_civicrm_membership_extras/pull/36/commits/b09dfe688ea297446aefa1917a757898c4089012) commit rounds the prorated membership items so they will look better in the discount block.

![2021-07-21_11-29](https://user-images.githubusercontent.com/74309109/126459353-e715f093-7e07-4672-84c3-677bd7bdafe4.png)
Instead of  
![2021-07-21_11-45](https://user-images.githubusercontent.com/74309109/126459612-1586e711-3aaa-4488-b8a6-628822e3ea5c.png)
