### PR TITLE
IO-341: Fix the prorated calculation if the membership select page was the last

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -823,9 +823,6 @@ function _webform_civicrm_membership_extras_get_instalment_amount_calculator($me
  */
 function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_state) {
   $membership_type_added = [];
-  if (!$form_state['input']) {
-    return $membership_type_added;
-  }
 
   $components = _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, '_membership_membership_type_id');
   foreach ($components as $key => $component) {
@@ -833,8 +830,9 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
     $membership_type_ids = [];
 
     // First, try to get the $membership_type_ids from the input array.
+    $submitted = $form_state['values']['submitted'] ?? [];
     $submittedInputsIterator = new RecursiveIteratorIterator(
-      new RecursiveArrayIterator($form_state['input']['submitted']),
+      new RecursiveArrayIterator($submitted),
       RecursiveIteratorIterator::SELF_FIRST);
     foreach($submittedInputsIterator as $fieldName => $field) {
       if ($fieldName === $component['form_key']) {

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -826,10 +826,13 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
 
   $components = _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, '_membership_membership_type_id');
   foreach ($components as $key => $component) {
-    // use array for membership_type ids because checkbox input allows mult-value.
-    $membership_type_ids = [];
+    // First, try to get the $membership_type_ids from the storage array if it
+    // was populated, which means this is another page, or it is an ajax request
+    // for applying the discount code. We use an array for membership_type ids
+    // because checkbox input allows mult-value.
+    $membership_type_ids = $form_state['storage']['submitted'][$key] ?? [];
 
-    // First, try to get the $membership_type_ids from the input array.
+    // Second, try to get the $membership_type_ids from the input array.
     $submitted = $form_state['values']['submitted'] ?? [];
     $submittedInputsIterator = new RecursiveIteratorIterator(
       new RecursiveArrayIterator($submitted),
@@ -840,11 +843,6 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
         break;
       }
     }
-
-    // Second, try to get the $membership_type_ids from the storage array if it
-    // was populated, which means this is another page, or it is an ajax request
-    // for applying the discount code.
-    $membership_type_ids = $form_state['storage']['submitted'][$key] ?? $membership_type_ids;
 
     if (!is_array($membership_type_ids)) {
       $membership_type_ids = [$membership_type_ids];

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -823,8 +823,9 @@ function _webform_civicrm_membership_extras_get_instalment_amount_calculator($me
  * @param array $form_state
  */
 function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_state) {
+  $membership_type_added = [];
   if (!$form_state['input']) {
-    return [];
+    return $membership_type_added;
   }
 
   $components = _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, '_membership_membership_type_id');

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -751,8 +751,7 @@ function _webform_civicrm_membership_extras_prorated_billing_form_alter_handler(
     return;
   }
 
-  $membershipTypes = _webform_civicrm_membership_extras_get_membership_types($form, $form_state);
-  if (!_webform_civicrm_membership_extras_is_prorated_billing_enabled($form, $form_state, $membershipTypes)) {
+  if (!_webform_civicrm_membership_extras_is_prorated_billing_enabled($form, $form_state)) {
     return;
   }
 
@@ -1003,6 +1002,26 @@ function _webform_civicrm_membership_extras_get_membership_dates(&$form, &$form_
 }
 
 /**
+ * Checks if the membership types are fixed.
+ *
+ * @param array $membershipTypes
+ */
+function _webform_civicrm_membership_extras_are_membership_types_fixed(array $membershipTypes) {
+  $areMembershipTypesFixed = TRUE;
+  foreach($membershipTypes as $membershipType) {
+    if($membershipType->period_type !== 'fixed') {
+      $areMembershipTypesFixed = FALSE;
+      break;
+    }
+  }
+  if (count($membershipTypes) < 1 || !$areMembershipTypesFixed) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
  * Calculates the prorated membership items.
  *
  * @param array $form
@@ -1010,6 +1029,9 @@ function _webform_civicrm_membership_extras_get_membership_dates(&$form, &$form_
  */
 function _webform_civicrm_membership_extras_update_the_prorated_membership_items($form, &$form_state) {
   $membershipTypes = _webform_civicrm_membership_extras_get_membership_types($form, $form_state);
+  if (!_webform_civicrm_membership_extras_are_membership_types_fixed($membershipTypes)) {
+    return FALSE;
+  }
 
   $components = $form['#node']->webform['components'];
   $membershipNamesAndKeysMap = [];
@@ -1050,22 +1072,10 @@ function _webform_civicrm_membership_extras_update_the_prorated_membership_items
  *
  * @param array $form
  * @param array $form_state
- * @param array $membershipTypes
  *
  * @return boolean
  */
-function _webform_civicrm_membership_extras_is_prorated_billing_enabled($form, &$form_state, $membershipTypes) {
-  $areMembershipTypesFixed = TRUE;
-  foreach($membershipTypes as $membershipType) {
-    if($membershipType->period_type !== 'fixed') {
-      $areMembershipTypesFixed = FALSE;
-      break;
-    }
-  }
-  if (count($membershipTypes) < 1 || !$areMembershipTypesFixed) {
-    return FALSE;
-  }
-
+function _webform_civicrm_membership_extras_is_prorated_billing_enabled($form, &$form_state) {
   $membershipSettings = $form['#node']->webform_civicrm['data']['membership'] ?? [];
   $isNumberOfTermsIsOne = TRUE;
   foreach($membershipSettings as $settings) {


### PR DESCRIPTION
## Overview
This PR fixes an issue that prevents the prorated calculation if the membership select page was the last.

## Before
The confirmation page shows the full price.

https://user-images.githubusercontent.com/74309109/143025653-98377069-52bb-4751-bb55-f5a12fcee961.mp4


## After
The confirmation page shows the prorated price.


https://user-images.githubusercontent.com/74309109/143025227-125703d7-70e4-4891-b26b-b06dadd62227.mp4


## Technical Details
The `webfrom_civicrm` module uses the `$form['#validate']` array to do the payment by adding a callback and the `webform` module will call those callbacks stored in the `$form['#validate']` array. We have to do the same and add our callback to  `$form['#validate']` array.
The function `_webform_civicrm_membership_extras_is_prorated_billing_enabled` checks the form whether prorated calculation should be enabled or not depending on certain criteria :  
- The number of terms is 1 (or the user choose "Manually Select")
- The membership fee is not set manually.
- The membership types are fixed.

The first two are related to webform configuration but the third one is related to the user's selected membership which we need to check the submitted form data before enabling the prorated calculation.
```php
  $membershipTypes = _webform_civicrm_membership_extras_get_membership_types($form, $form_state);
  if (!_webform_civicrm_membership_extras_is_prorated_billing_enabled($form, $form_state, $membershipTypes)) {
    return;
  }
  ...

  $form['#validate'][] = '_webform_civicrm_membership_extras_update_the_prorated_membership_items';
  $form['#validate'][] = '_webform_civicrm_membership_extras_set_prorated_membership_items_in_session';
```
So the result of the `_webform_civicrm_membership_extras_is_prorated_billing_enabled` function will be false if the user didn't select a membership hence we cannot add  our callbacks to the `$form['#validate']` array. This code runs during the `hook_form_alter` hook which fired before the rendering of the form , so if the user was at the membership select page and continued to the confirmation page, the code  will adds our callbacks to the `$form['#validate']` array but it will not get called because we are at the form rendering step (it is too late) and the confirmation page will show the full price because our callbacks were not called yet.
The second commit fixes this issue by delaying the check for membership types so we can always (if the webform configuration passed our remaining checks about the number of terms and the membership fee is not set manually) inject the validate callbacks so that we can do the prorated calculation at the confirmation page.

IO uses the webform's conditional expressions, which shed the light on another issue that we couldn't read the membership field that was created from applying conditional expressions. The third commit fixes it by using the  `$form_state['values']['submitted']` instead of `$form_state['input']['submitted']` to access the submitted form data.
The `$form_state['input']['submitted']` is identical to the global $_POST variable and doesn't have the new fields created from applying webform's conditional expressions. Moreover, the `$form_state['values']['submitted']` is the [most consistent way to
access the submitted form data](https://www.drupal.org/project/webform/issues/2136771#comment-8190157).

While working on this ticket, I solved another issue. At the confirmation page, if the user went back and edited the membership and continued to the confirmation page, he'll see the old membership's price selected instead of the new one's price.

https://user-images.githubusercontent.com/74309109/143034619-b872b440-dc3c-478b-a216-e7bace7eba08.mp4



The fourth commit fixes it.