### PR TITLE
BASW-923: Group discount fields together

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+## Comments
+_Anything else you would like the reviewer to note_

--- a/js/webform_civicrm_membership_extras.js
+++ b/js/webform_civicrm_membership_extras.js
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * JavaScript .
+ */
+
+ (function ($) {
+  Drupal.behaviors.acu_webform_draft_group = {
+    attach: function (context, settings) {
+      
+      let moveGroupDiscountFields = () => {
+        let discountCodeField = $('.webform-component--webform-discount-code-field')
+        let group = $('#edit-submitted-webform-discount-code-all-fields-wraper')
+        let discountCodeMessage = $('#discount-code-message-wrapper')
+        let discountCodeActions = $('#discount-code-actions')
+
+        if (group.length < 0) {
+          return
+        }
+
+        discountCodeField.appendTo(group)
+        discountCodeMessage.appendTo(group)
+        discountCodeActions.appendTo(group)
+      }
+
+      moveGroupDiscountFields()
+    }
+  }
+})(jQuery);

--- a/js/webform_civicrm_membership_extras.js
+++ b/js/webform_civicrm_membership_extras.js
@@ -4,9 +4,9 @@
  */
 
  (function ($) {
-  Drupal.behaviors.acu_webform_draft_group = {
+  Drupal.behaviors.webform_civicrm_membership_extras = {
     attach: function (context, settings) {
-      
+
       let moveGroupDiscountFields = () => {
         let discountCodeField = $('.webform-component--webform-discount-code-field')
         let group = $('#edit-submitted-webform-discount-code-all-fields-wraper')

--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -173,6 +173,12 @@ function wf_me_webform_client_form_alter_handler(&$form, &$form_state, $form_id)
   elseif (isset($form['submitted']['webform_discount_code_field'])) {
     _set_discount_code_status_in_session(FALSE);
     $fields = $form['submitted'];
+    $form['submitted']['webform_discount_code_all_fields_wraper'] = array(
+      '#type' => 'container',
+      '#weight' => $fields['webform_discount_code_field']['#weight'],
+      '#prefix' => '<div id="webform_discount_code_all_fields_wrapper">',
+      '#suffix' => '</br></div>',
+    );
     $form['submitted']['webform_discount_code_message_wrapper'] = array(
       '#type' => 'container',
       '#weight' => $fields['webform_discount_code_field']['#weight'],
@@ -233,6 +239,10 @@ function wf_me_webform_client_form_alter_handler(&$form, &$form_state, $form_id)
         $form['#validate'][] = $vc;
       }
     }
+
+    drupal_add_js(
+      drupal_get_path('module', 'webform_civicrm_membership_extras') . '/js/webform_civicrm_membership_extras.js'
+    );
   }
 
   if ($is_discount_enabled) {


### PR DESCRIPTION
## Overview
In this PR we resolve the issue with the `discount apply button` being separated from the `discount code input field` or not displayed on the screen.

## Before
`On client A`
<img width="866" alt="Screenshot 2022-07-28 at 14 53 17" src="https://user-images.githubusercontent.com/85277674/181522746-75f7ecc4-ef23-406e-aede-322aab41e0ea.png">

`On client B`
<img width="992" alt="Screenshot 2022-07-28 at 14 52 15" src="https://user-images.githubusercontent.com/85277674/181522285-6ab3af63-073b-4c41-8092-d3d67a09210a.png">


## After
<img width="956" alt="Screenshot 2022-07-28 at 15 26 42" src="https://user-images.githubusercontent.com/85277674/181546887-56e8b708-2808-4c26-8859-1dd01cf35545.png">

`Compuclient`
![aaa](https://user-images.githubusercontent.com/85277674/181720068-61b0cb53-9a4c-4d8f-93ff-326c097c58c8.gif)


## Technical Details
We tried grouping the discount fields together using fieldsets, but this didn't work. we opted for a JS solution to move the fields into the fieldset.
