### PR TITLE
EF-52: Ensure submitted field is not empty

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -892,7 +892,7 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
  * @param string $date_name
  */
 function _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name(&$form, &$form_state, $date_name) {
-  if (!$form_state['input']) {
+  if (!$form_state['input'] || empty($form_state['input']['submitted'])) {
     return [];
   }
 


### PR DESCRIPTION
## Overview
In this PR we resolve the issue with an error being displayed when clicking `Save Draft` on the Preview page of webforms

## Before
![aaaaa](https://user-images.githubusercontent.com/85277674/181752942-10d41e47-7616-41fe-b8d1-daa66c0c8508.gif)

## After
![aaaa](https://user-images.githubusercontent.com/85277674/181752934-c2b6742e-181a-4017-bb1e-4791540c0516.gif)

## Technical Details
This error happens because the `$form_state['input']['submitted']` array is NULL when the formed is saved as a draft, and RecursiveArrayIterator class expects an array. https://github.com/compucorp/webform_civicrm_membership_extras/blob/162210f2d86c4c83e30643b2cfc97b45a116d882/webform_civicrm_membership_extras.module#L903

To resolve the error we added a check at the top of the function, so it returns immediately if the form is being saved as a draft i.e. `$form_state['input']['submitted']` is empty.
