### PR TITLE
CIVIPLUS-976: fix no contribution membership webform signup

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -1035,6 +1035,7 @@ function _webform_civicrm_membership_extras_are_membership_types_fixed(array $me
  * @param array $form_state
  */
 function _webform_civicrm_membership_extras_update_the_prorated_membership_items($form, &$form_state) {
+  civicrm_initialize();
   $membershipTypes = _webform_civicrm_membership_extras_get_membership_types($form, $form_state);
   if (!_webform_civicrm_membership_extras_are_membership_types_fixed($membershipTypes)) {
     return FALSE;


### PR DESCRIPTION
## Overview
Provide Fix when someone try to create membership with 0 amount (100% discount)

## Before
blank white screen and in error 
`array(6) { 
 ["%type"]=> string(5) "Error" 
["!message"]=> string(57) "Class 'CRM_Member_BAO_MembershipType' not found" 
["%function"]=> string(57) "_webform_civicrm_membership_extras_get_membership_types()" 
["%file"]=> string(144) "/var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/webform_civicrm_membership_extras/webform_civicrm_membership_extras.module" 
["%line"]=> int(867) 
["severity_level"]=> int(3) 
}
`

## After
It will create membership with 100% discount

## Technical Details
CiviCRM is not initialise as its initialise on line 20 only if contribution id found.
