### PR TITLE
ESEB-113: Respect private and hidden membership start and end dates during pro-rata calculation

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -846,9 +846,12 @@ function _webform_civicrm_membership_extras_get_membership_types(&$form, &$form_
  * @param array $form
  * @param array $form_state
  * @param string $date_name
+ * @param string $form_data_key
+ *  Either 'input' to check if the date exists within the submitted form values,
+ *  or 'values' to check if the date exists within the form default values.
  */
-function _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name(&$form, &$form_state, $date_name) {
-  if (!$form_state['input'] || empty($form_state['input']['submitted'])) {
+function _webform_civicrm_membership_extras_get_membership_dates_from_form_by_name(&$form, &$form_state, $date_name, $form_data_key = 'input') {
+  if (!$form_state[$form_data_key] || empty($form_state[$form_data_key]['submitted'])) {
     return [];
   }
 
@@ -856,7 +859,7 @@ function _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_
   $part_of_form_key = "_membership_$date_name";
   $components = _webform_civicrm_membership_extras_get_components_by_part_of_form_key($form, $part_of_form_key);
   $submittedInputsIterator = new RecursiveIteratorIterator(
-    new RecursiveArrayIterator($form_state['input']['submitted']),
+    new RecursiveArrayIterator($form_state[$form_data_key]['submitted']),
     RecursiveIteratorIterator::SELF_FIRST);
   foreach ($components as $key => $component) {
     $date = 0;
@@ -865,8 +868,15 @@ function _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_
         $day = $field['day'] ?? 0;
         $month = $field['month'] ?? 0;
         $year = $field['year'] ?? 0;
+        // if "Date" field input type is used, then the date parts are split
+        // into an array of "day", "month" and "year".
         if ($day && $month && $year) {
          $date = intval($year) . "-" . intval($month) . "-" . intval($day);
+        }
+        // But if the input type is "Hidden", then the date will be a string,
+        // and it should have "Y-m-d" format.
+        elseif (!empty($field)) {
+          $date = $field;
         }
       }
     }
@@ -921,10 +931,19 @@ function _webform_civicrm_membership_extras_merge_membership_dates_by_membership
  */
 function _webform_civicrm_membership_extras_get_membership_dates(&$form, &$form_state, $membershipTypes, $membershipNamesAndKeysMap) {
   $membership_dates_added = [
-    'start_date' => _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name($form, $form_state, 'start_date'),
-    'end_date' => _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name($form, $form_state, 'end_date'),
-    'join_date' => _webform_civicrm_membership_extras_get_membership_dates_from_inputs_by_name($form, $form_state, 'join_date'),
+    'start_date' => _webform_civicrm_membership_extras_get_membership_dates_from_form_by_name($form, $form_state, 'start_date'),
+    'end_date' => _webform_civicrm_membership_extras_get_membership_dates_from_form_by_name($form, $form_state, 'end_date'),
+    'join_date' => _webform_civicrm_membership_extras_get_membership_dates_from_form_by_name($form, $form_state, 'join_date'),
   ];
+
+  // if the value is not present within the submitted form input, try to see
+  // if it has a default value and use it. This is needed when the date
+  // input is marked as "private" or "hidden" field with a default value.
+  foreach ($membership_dates_added as $membershipDateKey => $membershipDateValue) {
+    if (empty($membershipDateValue)) {
+      $membership_dates_added[$membershipDateKey] = _webform_civicrm_membership_extras_get_membership_dates_from_form_by_name($form, $form_state, $membershipDateKey, 'values');
+    }
+  }
 
   $membership_dates_added =
     _webform_civicrm_membership_extras_merge_membership_dates_by_membership_form_key($membership_dates_added, $membershipNamesAndKeysMap);


### PR DESCRIPTION
## Before

If you have a webform configured with the following:

- Fixed membership
- The number of terms = "Enter Dates Manually"
- With Either Start or End Date or both ticked
- And with either Start or End Date or both set as "Private" or "Hidden" field with a default value


Then the pro-rata calculation will not respect the start or the end date that are configured as default values on the webform.

e.g 
Here is an example webform that is configured with one fixed membership and private end date with the default value = "2023-12-21":



![2023-12-14 16_12_35-test _ Site-Install](https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/c59fec5c-e9c6-4dfc-a1c0-ebcc29f1ae99)

![2023-12-14 16_14_12-Edit component_ End Date _ Site-Install](https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/85a9f3b6-9847-4c65-a292-d594a2e5a2d7)

![2023-12-14 16_14_29-Edit component_ End Date _ Site-Install](https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/1bdbc74a-de55-41b9-b86e-a4f769941b99)


The fixed membership type that is used in the above webform has the end date of "31 December" with annual Fee = $100

![image](https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/db0b4097-deca-4a5d-b795-596aeda89355)

so the fee of single day in non leap year is: $100/365 = $0.273972603

If I submit the webform above at  "2023-12-14", then it should do the pro-rata for 8 days (which is the number of days between "2023-12-14" and "2023-12-21") , so it should be = $0.273972603 * 8 = $2.19 but instead we will get $4.93 (which is $0.273972603 * 18) :

![image](https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/84c0bbe4-1251-44cb-b8e3-cd26755b28cd)

because the webform did not use the end date that is configured as default value, and instead it used the end that is configured in the membership type settings.

## After

Webforms now respect the provided default values for the start or end date if they are hidden or private.

In the above example, we can see how the the fee is now displayed correctly as $2.19

![image](https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/85cb0dc5-557a-4691-9b3c-84d013041ecc)

## Technical details 


This function is the one responsible for getting the selected membership start and end dates for the pro-rata calculation: `_webform_civicrm_membership_extras_get_membership_dates` which calls this other function `_webform_civicrm_membership_extras_get_membership_dates_from_form_by_name` .

The problem with this function is that it assumes the start and the end dates are available inside the `$form_state['input']['submitted']` field, which is true if the date fields are visible in the webform, but if they are not as it is the case with hidden or private fields, then they will be instead inside `$form_state['values']['submitted']`. So I altered the code to get the start and end date values from  `$form_state['values']['submitted']` in case they are not inside `$form_state['input']['submitted']`.
