### PR TITLE
PROD-165: Fix pro-rata calculation regression caused by PROD-165 work

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -1082,7 +1082,7 @@ function _webform_civicrm_membership_extras_update_the_prorated_membership_items
         $line_items[$line_item_key]['line_total'] = (float) number_format( $line_items[$line_item_key]['line_total'], 2, '.', '');
         $line_items[$line_item_key]['tax_amount'] = $instalmentLineItems[0]->getTaxAmount();
         $line_items[$line_item_key]['tax_amount'] = (float) number_format( $line_items[$line_item_key]['tax_amount'], 2, '.', '');
-        $line_items[$line_item_key]['membership_type_id'] = $membershipTypes[$key]['type_id']->id;
+        $line_items[$line_item_key]['membership_type_id'] = $membershipTypes[$key]['type_data']->id;
 
         $prorated_start_date = DateTime::createFromFormat('Ymd', $membershipDates[$key]['start_date']);
         $line_items[$line_item_key]['prorated_start_date'] = $prorated_start_date->format('Y-m-d');


### PR DESCRIPTION
## Overview

After this PR: https://github.com/compucorp/webform_civicrm_membership_extras/pull/62
the pro-rata calculation seems to happen just fine while going through webform pages, but once the webform is submitted, the contribution that is created will be have the full membership price instead of the pro-rata amount that showed up before submitting the webform.

## Before

https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/09043fbf-9516-4f77-883e-dc6e256a16f4


## After


https://github.com/compucorp/webform_civicrm_membership_extras/assets/6275540/408b32c0-b487-4550-8fd2-4648076f3802


## Technical

I made a typo in previous PR where I introduced new array key inside the membership types array called `type_data`, but then in one location I wrote `type_id` instead, so I changed it back to `type_data`, 