### PR TITLE
COMCL-1354: Fix Contribution Rounding Issue

### DIFF
--- a/webform_civicrm_membership_extras.module
+++ b/webform_civicrm_membership_extras.module
@@ -1078,7 +1078,7 @@ function _webform_civicrm_membership_extras_update_the_prorated_membership_items
       if (isset($membershipNamesAndKeysMap[$item['element']]) && $membershipNamesAndKeysMap[$item['element']] === $key) {
         $line_items[$line_item_key]['unit_price'] = $instalmentLineItems[0]->getUnitPrice();
         $line_items[$line_item_key]['unit_price'] = number_format( $line_items[$line_item_key]['unit_price'], 2, '.', '');
-        $line_items[$line_item_key]['line_total'] = $instalmentLineItems[0]->getTotalAmount() - $instalmentLineItems[0]->getTaxAmount();
+        $line_items[$line_item_key]['line_total'] = $instalmentLineItems[0]->getSubTotal();
         $line_items[$line_item_key]['line_total'] = (float) number_format( $line_items[$line_item_key]['line_total'], 2, '.', '');
         $line_items[$line_item_key]['tax_amount'] = $instalmentLineItems[0]->getTaxAmount();
         $line_items[$line_item_key]['tax_amount'] = (float) number_format( $line_items[$line_item_key]['tax_amount'], 2, '.', '');


### PR DESCRIPTION
## Overview
This Pr fixes an issue due to which the membership contribution amount was being shown with an increment of one cent due to a rounding issue.


## Technical Details
Previously we were recalculating the line_total for each line item by subtracting the tax from total amount but this PR changes to use already calculated subtotal from line item which resolves the rounding issue.

## Example
Lets assume a fixed membership signup with a 100 pounds fee and vat of 20% which makes the total amount equals to 120 and if we signup with a membership start date of 15 Jan then the correct pro rated amount is 115.39 but previously we were calculating the total as 115.40.